### PR TITLE
Fix for failed fetch of one of curl

### DIFF
--- a/gerrit/Dockerfile
+++ b/gerrit/Dockerfile
@@ -2,7 +2,7 @@ FROM gerritforge/gerrit-ubuntu15.04:2.11.3
 MAINTAINER svanoort
 
 USER root
-RUN apt-get install -y curl python net-tools && \
+RUN apt-get update && apt-get install -y curl python net-tools && \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo \
     && chmod a+x /bin/repo

--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -10,7 +10,7 @@ mailer:1.15
 mapdb-api:1.0.6.0
 mercurial:1.54
 scm-api:0.2
-script-security:1.15
+script-security:1.17
 subversion:2.5
 workflow-aggregator:@VERSION@
 workflow-api:@VERSION@


### PR DESCRIPTION
Out of the box the gerrit image could not be built. Adding a apt-get update fixed it.

The error was:

```
Step 1-3
...
Step 4 : RUN apt-get install -y curl python net-tools &&     rm -rf /var/lib/apt/lists/*
 ---> Running in 3021ffe9d074
Reading package lists...
Building dependency tree...
Reading state information...
python is already the newest version.
python set to manually installed.
The following NEW packages will be installed:
  curl libcurl3 net-tools
0 upgraded, 3 newly installed, 0 to remove and 56 not upgraded.
Need to get 484 kB of archives.
After this operation, 1629 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu/ vivid/main net-tools amd64 1.60-26ubuntu1 [175 kB]
Err http://archive.ubuntu.com/ubuntu/ vivid-security/main libcurl3 amd64 7.38.0-3ubuntu2.2
  404  Not Found [IP: 91.189.92.200 80]
EErr http://archive.ubuntu.com/ubuntu/ vivid-security/main curl amd64 7.38.0-3ubuntu2.2
  404  Not Found [IP: 91.189.92.200 80]
Fetched 175 kB in 0s (406 kB/s)
: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl3_7.38.0-3ubuntu2.2_amd64.deb  404  Not Found [IP: 91.189.92.200 80]

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/curl/curl_7.38.0-3ubuntu2.2_amd64.deb  404  Not Found [IP: 91.189.92.200 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get install -y curl python net-tools &&     rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```
